### PR TITLE
Added editor attirbutes for revisions

### DIFF
--- a/hiki/db/rdb.rb
+++ b/hiki/db/rdb.rb
@@ -121,7 +121,7 @@ module Hiki
         end
         @db[:page].where(wiki: @wiki, name: page).update(attribute => value)
         unless %w(references count freeze).include?(attribute)
-          @db[:page_backup].where(wiki: @wiki, name: page).order(:revision).limit(1).update(attribute => value)
+          @db[:page_backup].where(wiki: @wiki, name: page).reverse_order(:revision).limit(1).update(attribute => value)
         end
       end
     end


### PR DESCRIPTION
History に記録されていない問題の修正です。db からリビジョン一覧を取得する時に page_backup のデータに editor が入っていないのが原因のようです。ひとまず `@user`入れてみましたが、ログインが絡むテストコードを書くのは大変なので、実際に動作テストして確認しようと思います。

fixes https://github.com/rubima/hiki/issues/11
