### PR TITLE
update atom.xml for Rubyist Magazine #52 release

### DIFF
--- a/public/atom.xml
+++ b/public/atom.xml
@@ -13,7 +13,7 @@
   <entry>
     <title type="html"><![CDATA[Rubyist Magazine 0052 号]]></title>
     <link href="http://magazine.rubyist.net/?0052"/>
-    <updated>2015-09-06T22:30:00+09:00</updated>
+    <updated>2015-12-06T21:30:00+09:00</updated>
     <id>http://magazine.rubyist.net/?0052</id>
     <content type="html"><![CDATA[
 <h1 class="header">Rubyist Magazine 0052 号</h1>

--- a/public/atom.xml
+++ b/public/atom.xml
@@ -4,11 +4,63 @@
   <title><![CDATA[Rubyist Magazine - るびま]]></title>
   <link href="http://magazine.rubyist.net/atom.xml" rel="self"/>
   <link href="http://magazine.rubyist.net/"/>
-  <updated>2015-09-06T22:30:00+09:00</updated>
+  <updated>2015-12-06T21:30:00+09:00</updated>
   <id>http://magazine.rubyist.net/</id>
   <author>
     <name><![CDATA[RubiMa Editors]]></name>
   </author>
+
+  <entry>
+    <title type="html"><![CDATA[Rubyist Magazine 0052 号]]></title>
+    <link href="http://magazine.rubyist.net/?0052"/>
+    <updated>2015-09-06T22:30:00+09:00</updated>
+    <id>http://magazine.rubyist.net/?0052</id>
+    <content type="html"><![CDATA[
+<h1 class="header">Rubyist Magazine 0052 号</h1>
+<p>『るびま』は、Ruby に関する技術記事はもちろんのこと、Rubyist へのインタビューやエッセイ、その他をお届けするウェブ雑誌です。</p>
+<h2>目次</h2>
+<h3><a href="./?0052-ForeWord">巻頭言</a></h3>
+<p>書いた人：るびま編集長 高橋征義<br/>
+編集長からの 0052 号発行の挨拶です。(難易度：高)</p>
+<h3><a href="./?FirstStepRuby">Ruby の歩き方</a></h3>
+<p>Ruby をはじめるにあたって必要な情報をご紹介します。本稿は Rubyist Magazine 常設記事です。(難易度：低)</p>
+<h3><a href="./?0052-Hotlinks">Rubyist Hotlinks 【第 35 回】 島田浩二さん</a></h3>
+<p>Rubyist へのインタビュー企画。今回は島田浩二さんにお話を伺いました。(難易度：北海道)</p>
+<h3><a href="./?0052-esaio">esa.io の作り方</a></h3>
+<p>書いた人：fukayatsu さん<br />
+esa.io の裏側の紹介記事です。（難易度：(\\( ⁰⊖⁰)/)）</p>
+<h3><a href="./?0052-RubyConfTaiwan2015">RubyConf Taiwan 2015 レポート</a></h3>
+<p>書いた人：yucao24hours さん<br />
+2015 年 9 月に台湾で開催された RubyConf Taiwan  2015の参加レポートです。（難易度：よちよちからムキムキまで）</p>
+<h3><a href="./?0052-MatsueRubyKaigi07Report">RegionalRubyKaigi レポート (55) 松江 Ruby 会議 07</a></h3>
+<p>書いた人：西田 雄也 さん、佐田 明弘 さん、井上 裕之 さん、本多 展幸 さん、木村 友哉 さん、橋本 将 さん<br />
+2015 年 9 月に島根県松江市で開催された 松江 Ruby 会議 07 の報告です。(難易度：いろいろ)</p>
+<h3><a href="./?0052-RubyistMagazineRanking">るびまアクセスランキング Vol.52</a></h3>
+<p>0051 号リリース時点から 0052 号リリース直前までの、るびまの記事のアクセスランキングです。</p>
+<h3><a href="./?0052-present-feedback">プレゼント当選者からのフィードバック</a></h3>
+<p>0050 号でのプレゼント当選者から感想をブログに記していただきましたので、ご紹介します。</p>
+<h3><a href="https://github.com/ruby-no-kai/official/wiki/RubyEventCheck" class="external">RubyEventCheck</a></h3>
+<p>Ruby 関連、または Rubyist が興味を持ちそうなイベントをご紹介します。本稿は <a href="https://github.com/ruby-no-kai/official/wiki" class="external">日本 Ruby の会 公式 Wiki</a> にて常時更新されている同名ページへのリンクとなります。(難易度：低)</p>
+<h3><a href="./?0052-EditorsNote">0052 号 編集後記</a></h3>
+<h2>次号予告</h2>
+<p>次号は 2016 年 4 月頃にリリースする予定です。</p>
+<h3>掲載予定記事</h3>
+<ul>
+<li>RegionalRubyKaigi レポート</li>
+</ul>
+<h2>おねがい</h2>
+<p>記事へのご意見、ご感想や、「こんな記事が読みたい」、「あの人の記事が読みたい」、といったご希望などがありましたら、下記連絡先までお気軽にお寄せください。</p>
+<p>記事の投稿も随時受け付けております。</p>
+<ul>
+<li>Ruby に関する技術記事・解説記事</li>
+<li>Ruby 活用事例</li>
+<li>Ruby がちょっとでも絡むエッセイ</li>
+<li>Ruby に関するその他</li>
+</ul>
+<p>などを募集しております。何かネタがありましたらご連絡ください。また、編集に参加したいというお申し出も大歓迎です。</p>
+<p>連絡先 : <a href="mailto:magazine@ruby-no-kai.org" class="external">るびま編集部</a>、<a href="https://github.com/rubima/rubima-support" class="external">るびまサポートリポジトリ</a></p>
+]]></content>
+  </entry>
 
   <entry>
     <title type="html"><![CDATA[Rubyist Magazine 0051 号]]></title>


### PR DESCRIPTION
update atom.xml for Rubyist Magazine #52 release

るびま52号リリースに伴い、RSS用のXMLファイルを更新しました。

see. rubima/rubima#378
