### PR TITLE
Fix rubima/rubima#216 and rubima/hiki#1.

### DIFF
--- a/hiki/command.rb
+++ b/hiki/command.rb
@@ -148,7 +148,12 @@ module Hiki
       data[:body_enter] = @body_enter
       data[:lang] = @conf.lang
       data[:header] = @plugin.header_proc
-      data[:body_leave] = @plugin.body_leave_proc
+      if !@plugin.auth? && @db.get_attribute(@p, :keyword).include?('auth')
+        data[:body_leave] = ''
+      else
+        data[:body_leave] = @plugin.body_leave_proc
+      end
+
       data[:page_attribute] ||= ''
       data[:footer] = @plugin.footer_proc
       data.update( @plugin.data ) if @plugin.data


### PR DESCRIPTION
注釈が見える問題を解決してみました。
rubima/rubima#216 and rubima/hiki#1

plugin本体（misc/plugin/footnote.rb）を修正したいところであったが、
ログイン時にも注釈が見えてしまう問題が発生してしまう。